### PR TITLE
Automatic tenant lookup

### DIFF
--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from "electron";
+import { app, BrowserWindow } from "electron";
 import { TokenResponse } from "adal-node";
 import { adalAuth } from "./adalAuth";
 import https from "https";
@@ -32,7 +32,12 @@ function getTenantUrl(envUrl: string): Promise<string> {
 }
 
 export async function authenticate(tenant: string, envUrl: string): Promise<TokenResponse> {
-  tenant = await getTenantUrl(envUrl);
+  app.allowRendererProcessReuse = true;
+
+  const [_, url] =  await Promise.all([
+    app.whenReady(),
+    getTenantUrl(envUrl)
+  ]);
 
   return new Promise((resolve, reject) => {
     let loginComplete = false;
@@ -50,7 +55,7 @@ export async function authenticate(tenant: string, envUrl: string): Promise<Toke
     });
 
     // Navigate to the get code page
-    win.loadURL(`${tenant}?client_id=51f81489-12ee-4a9e-aaae-a2591f45987d&response_type=code&haschrome=1&redirect_uri=app%3A%2F%2F58145B91-0C36-4500-8554-080854F2AC97&scope=openid`);
+    win.loadURL(`${url}?client_id=51f81489-12ee-4a9e-aaae-a2591f45987d&response_type=code&haschrome=1&redirect_uri=app%3A%2F%2F58145B91-0C36-4500-8554-080854F2AC97&scope=openid`);
     win.on("closed", function() {
       if (!loginComplete) {
         reject("Login Closed");

--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -37,6 +37,7 @@ export async function authenticate(tenant: string, envUrl: string): Promise<Toke
   return new Promise((resolve, reject) => {
     let loginComplete = false;
 
+    // Create the browser window.
     const win = new BrowserWindow({
       width: 800,
       height: 600,

--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -1,10 +1,42 @@
 import { BrowserWindow } from "electron";
 import { TokenResponse } from "adal-node";
 import { adalAuth } from "./adalAuth";
-export function authenticate(tenant: string, envUrl: string): Promise<TokenResponse> {
+import https from "https";
+
+// Create the browser window.
+function getTenantUrl(envUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let url = envUrl.endsWith("/")
+      ? `${envUrl}api/data`
+      : `${envUrl}/api/data`;
+    
+    url = !url.startsWith("http://") && !url.startsWith("https://")
+      ? `https://${url}`
+      : url.replace("http://", "https://"); 
+    
+    https.get(url, (response) => {
+      if (response.headers["www-authenticate"]) {
+        try {
+          resolve(response.headers["www-authenticate"].split("=")[1].split(",")[0]);
+        } catch(err) {
+          console.log("Failed to parse 'www-authenticate' header from Environment\n\n" + response.headers["www-authenticate"]);
+          reject("Failed to parse 'www-authenticate' header from Environment");
+        }
+      } else {
+        const message = `${envUrl} is not valid Environment`; 
+        console.log(message)
+        reject(message);
+      }
+    });
+  });
+}
+
+export async function authenticate(tenant: string, envUrl: string): Promise<TokenResponse> {
+  tenant = await getTenantUrl(envUrl);
+
   return new Promise((resolve, reject) => {
     let loginComplete = false;
-    // Create the browser window.
+
     const win = new BrowserWindow({
       width: 800,
       height: 600,
@@ -15,9 +47,9 @@ export function authenticate(tenant: string, envUrl: string): Promise<TokenRespo
         nodeIntegration: true,
       },
     });
-    const url = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?client_id=51f81489-12ee-4a9e-aaae-a2591f45987d&response_type=code&haschrome=1&redirect_uri=app%3A%2F%2F58145B91-0C36-4500-8554-080854F2AC97&scope=openid`;
+
     // Navigate to the get code page
-    win.loadURL(url);
+    win.loadURL(`${tenant}?client_id=51f81489-12ee-4a9e-aaae-a2591f45987d&response_type=code&haschrome=1&redirect_uri=app%3A%2F%2F58145B91-0C36-4500-8554-080854F2AC97&scope=openid`);
     win.on("closed", function() {
       if (!loginComplete) {
         reject("Login Closed");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { app } from "electron";
 import { authenticate } from "./authenticate";
 import { addTokenToCache } from "./TokenCache";
 import { version } from "./version";
@@ -13,8 +12,6 @@ console.log(`Authenticating for Tenant:'${argTenant}' and Environment:'${argEnvU
 main();
 
 async function main(): Promise<void> {
-  app.allowRendererProcessReuse = true;
-  await app.whenReady();
   try {
     const token = await authenticate(argTenant, argEnvUrl);
     // Save token to token cache


### PR DESCRIPTION
I have implemented automatic tenant lookup.

I've seen this method here: https://crmtipoftheday.com/1271/where-is-my-tenant-id/ far less pain then conventional way.

However I'm not able to make it optional, because tenant id in your code is not the last argument and if I proceed I will definitely introduce breaking changes, which I believe you would prefer to have full control over. So tenant is still expected from command line but not used anywhere :)

I believe if you would like this change it won't be a huge issue to justify rest of the code accordingly.